### PR TITLE
chore: require at lest node 14 and configure Github action accordingly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        node: ['12.0']
+        node: ['14.0']
     name: Testing Node ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        node: ['12.0', '14.0', '16.0']
+        node: ['14.0', '16.0', '18.0']
     name: Testing Node ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test": "nyc mocha"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Node 12 is not maintained anymore. (Even if node 18 is not yet a LTS, I configure the test matrix with it to be future proof)